### PR TITLE
Fix bootstrap script for older AMI versions

### DIFF
--- a/mrjob.conf
+++ b/mrjob.conf
@@ -22,7 +22,7 @@ runners:
     ami_version: 3.0.4
     interpreter: python2.7
     bootstrap:
-    - sudo yum install -y python27 python27-devel gcc-c++
+    - sudo yum --releasever=2014.09 install -y python27 python27-devel gcc-c++
     - sudo python2.7 get-pip.py#
     - sudo pip2.7 install boto mrjob simplejson warc
     - sudo pip2.7 install https://github.com/commoncrawl/gzipstream/archive/master.zip


### PR DESCRIPTION
Source of fix: https://forums.aws.amazon.com/message.jspa?messageID=614195

With the old mrjob configuration, the commands in the ReadMe don't run out of
the box - instance boostrapping crashes with a "transaction check error". The
issue arises due to changes in the yum package environment and its dependencies.
Specifying a particular yum version (see this commit) fixes the problem.