### PR TITLE
Moving a message away from the `print` to `logging`

### DIFF
--- a/mrcc.py
+++ b/mrcc.py
@@ -11,7 +11,7 @@ from mrjob.util import log_to_stream
 # Set up logging
 # Duplicate log messages caused by: https://github.com/Yelp/mrjob/issues/1551
 LOG = logging.getLogger(__name__)
-log_to_stream(format="%(asctime)s;%(levelname)s;%(message)s")
+log_to_stream(format="%(asctime)s;%(levelname)s;%(message)s", name=__name__)
 
 class CCJob(MRJob):
     """

--- a/mrcc.py
+++ b/mrcc.py
@@ -1,4 +1,5 @@
 import gzip
+import logging
 import os.path as Path
 import boto
 import warc
@@ -6,6 +7,7 @@ from boto.s3.key import Key
 from gzipstream import GzipStreamFile
 from mrjob.job import MRJob
 
+log = logging.getLogger(__name__)
 
 class CCJob(MRJob):
     def configure_options(self):
@@ -31,7 +33,7 @@ class CCJob(MRJob):
         # If we're local, use files on the local file system
         else:
             line = Path.join(Path.abspath(Path.dirname(__file__)), line)
-            print 'Loading local file {}'.format(line)
+            log.info('Loading local file {}'.format(line))
             ccfile = warc.WARCFile(fileobj=gzip.open(line))
 
         for i, record in enumerate(ccfile):

--- a/mrcc.py
+++ b/mrcc.py
@@ -1,15 +1,22 @@
 import gzip
 import logging
 import os.path as Path
-import boto
 import warc
+import boto
 from boto.s3.key import Key
 from gzipstream import GzipStreamFile
 from mrjob.job import MRJob
+from mrjob.util import log_to_stream
 
-log = logging.getLogger(__name__)
+# Set up logging
+# Duplicate log messages caused by: https://github.com/Yelp/mrjob/issues/1551
+LOG = logging.getLogger(__name__)
+log_to_stream(format="%(asctime)s;%(levelname)s;%(message)s")
 
 class CCJob(MRJob):
+    """
+    A simple way to run MRJob jobs on CommonCrawl Data
+    """
     def configure_options(self):
         super(CCJob, self).configure_options()
         self.pass_through_option('--runner')
@@ -22,6 +29,12 @@ class CCJob(MRJob):
         raise NotImplementedError('Process record needs to be customized')
 
     def mapper(self, _, line):
+        """
+        The Map of MapReduce
+        If you're using Hadoop or EMR, it pulls the CommonCrawl files from S3,
+        otherwise it pulls from the local filesystem. Dispatches each file to
+        `process_record`.
+        """
         # If we're on EC2 or running on a Hadoop cluster, pull files via S3
         if self.options.runner in ['emr', 'hadoop']:
             # Connect to Amazon S3 using anonymous credentials
@@ -33,7 +46,7 @@ class CCJob(MRJob):
         # If we're local, use files on the local file system
         else:
             line = Path.join(Path.abspath(Path.dirname(__file__)), line)
-            log.info('Loading local file {}'.format(line))
+            LOG.info('Loading local file {}'.format(line))
             ccfile = warc.WARCFile(fileobj=gzip.open(line))
 
         for i, record in enumerate(ccfile):
@@ -47,4 +60,9 @@ class CCJob(MRJob):
             yield key_val
 
     def reducer(self, key, value):
+        """
+        The Reduce of MapReduce
+        If you're trying to count stuff, this `reducer` will do. If you're
+        trying to do something more, you'll likely need to override this.
+        """
         yield key, sum(value)


### PR DESCRIPTION
The print statement ended up in the mapper's output. If you run something with the `inline` runner, it works fine, but if you run something with the `local` runner, it blows up.

I think _any_ `print` statement w/in the mrjob context is going to break things. I can confirm it breaks things if you include extra `print`s in the mapper.

(Including the call stack, so future searchers have something to look for)
> Traceback (most recent call last):
  File "myapp.py", line 60, in <module>
    MyApp.run()
  File "/private/var/folders/w8/l_0frgpx5y18fdjnwl05x73h0000gp/T/myapp.AdamP.20171003.032506.719205/job_local_dir/0/mapper/0/mrjob.zip/mrjob/job.py", line 439, in run
  File "/private/var/folders/w8/l_0frgpx5y18fdjnwl05x73h0000gp/T/myapp.AdamP.20171003.032506.719205/job_local_dir/0/mapper/0/mrjob.zip/mrjob/job.py", line 451, in execute
  File "/private/var/folders/w8/l_0frgpx5y18fdjnwl05x73h0000gp/T/myapp.AdamP.20171003.032506.719205/job_local_dir/0/mapper/0/mrjob.zip/mrjob/job.py", line 612, in run_combiner
  File "/Users/AdamP/git/cc-mrjob/mrcc.py", line 44, in combiner
    for key_val in self.reducer(key, value):
  File "myapp.py", line 54, in reducer
    for pagedata in pagedatas:
  File "/private/var/folders/w8/l_0frgpx5y18fdjnwl05x73h0000gp/T/myapp.AdamP.20171003.032506.719205/job_local_dir/0/mapper/0/mrjob.zip/mrjob/job.py", line 611, in <genexpr>
  File "/private/var/folders/w8/l_0frgpx5y18fdjnwl05x73h0000gp/T/myapp.AdamP.20171003.032506.719205/job_local_dir/0/mapper/0/mrjob.zip/mrjob/job.py", line 708, in read_lines
  File "/private/var/folders/w8/l_0frgpx5y18fdjnwl05x73h0000gp/T/myapp.AdamP.20171003.032506.719205/job_local_dir/0/mapper/0/mrjob.zip/mrjob/protocol.py", line 90, in read
ValueError: need more than 1 value to unpack
Step 1 of 1 failed: Command '['sh', '-ex', 'setup-wrapper.sh', '/Users/AdamP/git/cc-mrjob/env/bin/python', 'myapp.py', '--step-num=0', '--combiner', '-r', 'local']' returned non-zero exit status 1