### PR TITLE
Support WARC/1.1

### DIFF
--- a/mrcc.py
+++ b/mrcc.py
@@ -7,6 +7,9 @@ from tempfile import TemporaryFile
 import boto3
 import botocore
 import warc
+# work-around to enable support of WARC/1.1
+if '1.1' not in warc.warc.WARCReader.SUPPORTED_VERSIONS:
+    warc.warc.WARCReader.SUPPORTED_VERSIONS.append('1.1')
 
 from mrjob.job import MRJob
 from mrjob.util import log_to_stream


### PR DESCRIPTION
- work-around as this is unlikely to be implemented in the [warc module](/internetarchive/warc)
- see also commoncrawl/cc-pyspark#3